### PR TITLE
реализован API для получения списка всех пользователей

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,11 +1,13 @@
 from fastapi import FastAPI, Depends, HTTPException, status
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import Response, JSONResponse
+from fastapi.responses import Response
 from datetime import datetime
 import uvicorn
 from models import User, UserResponse, Token
+from models import User, UserResponse, Token, UserListItem, UserListResponse, USERS
 from auth import get_current_user, create_access_token, verify_password
 from datetime import timedelta
+
 
 app = FastAPI()
 
@@ -46,6 +48,36 @@ async def serve_frontend():
 async def health_check():
     """Health check endpoint"""
     return {"status": "healthy", "timestamp": datetime.utcnow().isoformat()}
+
+@app.get("/users", response_model=UserListResponse)
+async def get_all_users():
+    """Получение списка всех зарегистрированных пользователей"""
+    try:
+        # Преобразуем хардкодированных пользователей в нужный формат
+        users_list = []
+
+        for username, user_data in USERS.items():
+            user_item = UserListItem(
+                username=user_data["username"],
+                full_name=user_data["full_name"],
+                role=user_data["role"]
+            )
+            users_list.append(user_item)
+
+        # Формируем ответ
+        response = UserListResponse(
+            users=users_list,
+            total=len(users_list),
+            timestamp=datetime.utcnow().isoformat()
+        )
+
+        return response
+
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Ошибка при получении списка пользователей: {str(e)}"
+        )
 
 
 if __name__ == "__main__":

--- a/models.py
+++ b/models.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel
+from typing import List
 
 class User(BaseModel):
     username: str
@@ -12,6 +13,18 @@ class UserResponse(BaseModel):
 class Token(BaseModel):
     access_token: str
     token_type: str
+
+class UserListItem(BaseModel):
+    """Модель для элемента списка пользователей"""
+    username: str
+    full_name: str
+    role: str
+
+class UserListResponse(BaseModel):
+    """Модель ответа со списком пользователей"""
+    users: List[UserListItem]
+    total: int
+    timestamp: str
 
 # Хардкод пользователей
 USERS = {


### PR DESCRIPTION
Реалзован API endpoint GET /users, который возвращает список всех зарегистрированных пользователей из захардхорженного массива USERS. Созданы две Pydantic модели: UserListItem для отдельных записей с полями username, full_name и role, и UserListResponse как контейнер ответа с дополнительными метаданными total и timestamp. <br>
В endpoint-е используется линейное преобразование данных - производятся итерации по словарю USERS с созданием объектов UserListItem. Код обернут в try-catch для обработки исключений с возвратом HTTP 500 и информативным сообщением об ошибке, предотвращая падение приложения.